### PR TITLE
Tweak circleci configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,19 +23,8 @@ aliases:
 
 version: 2
 jobs:
-  test-node-9:
-    working_directory: ~/metro/packager/metro
-    docker:
-      - image: circleci/node:9
-    steps:
-      - checkout
-      - restore-cache: *restore-cache
-      - run: yarn --no-progress
-      - save-cache: *save-cache
-      - run: yarn run test-ci
-
-  test-node-8:
-    working_directory: ~/metro/packager/metro
+  run-js-checks:
+    working_directory: ~/metro
     docker:
       - image: circleci/node:8
     steps:
@@ -44,9 +33,30 @@ jobs:
       - run: yarn --no-progress
       - save-cache: *save-cache
       - run: yarn run test-ci
+  test-node-9:
+    working_directory: ~/metro
+    docker:
+      - image: circleci/node:9
+    steps:
+      - checkout
+      - restore-cache: *restore-cache
+      - run: yarn --no-progress
+      - save-cache: *save-cache
+      - run: yarn run jest
+
+  test-node-8:
+    working_directory: ~/metro
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - restore-cache: *restore-cache
+      - run: yarn --no-progress
+      - save-cache: *save-cache
+      - run: yarn run jest
 
   test-node-6:
-    working_directory: ~/metro/packager/metro
+    working_directory: ~/metro
     docker:
       - image: circleci/node:6
     steps:
@@ -55,10 +65,10 @@ jobs:
       - run: sudo npm i -g yarn@^1.2.1
       - run: yarn --no-progress
       - save-cache: *save-cache
-      - run: yarn run test-ci
+      - run: yarn run jest
 
-  deploy:
-    working_directory: ~/metro/packager/metro
+  publish-to-npm:
+    working_directory: ~/metro
     docker:
       - image: circleci/node:8
     steps:
@@ -69,7 +79,7 @@ jobs:
           command: yarn --no-progress
       - save-cache: *save-cache
       - run:
-          working_directory: ~/metro/
+          working_directory: ~/metro
           run: yarn build
       - run:
           working_directory: packages/metro
@@ -95,11 +105,12 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
+      - run-js-checks
       - test-node-6
       - test-node-8
       - test-node-9
       - test-and-deploy-website
-      - deploy:
+      - publish-to-npm:
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
We've had the node v6 test step failing for some time now (due to https://github.com/prettier/prettier/issues/3457).

Since there seems to be no progress on that issue, I'm adopting a similar approach that React Native has done to work around the issue: run the linter and flow on the latest nodejs version, and only run the jest tests on previous versions (this is also that jest seems to be doing as well).

For this I've created a run-js-checks step, while the jest tests are still under the test-node-X steps

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
